### PR TITLE
Quote URLs to guarantee data type

### DIFF
--- a/input/fsh/KLCommonCodeSystem.fsh
+++ b/input/fsh/KLCommonCodeSystem.fsh
@@ -1,7 +1,7 @@
 CodeSystem: NPU
 Title: "NPU"
 Description: "NPUcodes used in Danish municipalities"
-* ^url = urn:oid:1.2.208.176.2.1
+* ^url = "urn:oid:1.2.208.176.2.1"
 * ^content = http://hl7.org/fhir/codesystem-content-mode#fragment
 * ^experimental = false
 * ^caseSensitive = true


### PR DESCRIPTION
Upcoming changes in SUSHI version 3 allow for Instance assignment in rules that previously did not permit Instance assignment. This change is consistent with the existing FSH specification. The changes in this PR will help avoid errors when using SUSHI version 3.